### PR TITLE
feat(auth): Implement public user self-registration endpoint

### DIFF
--- a/backend-nest/src/auth/auth.controller.ts
+++ b/backend-nest/src/auth/auth.controller.ts
@@ -2,19 +2,28 @@ import {
   Controller,
   Post,
   Body,
+  HttpCode,
+  HttpStatus,
   UseGuards,
   Request,
   Get,
+  BadRequestException,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { LocalAuthGuard } from './guards/local-auth.guard'; // Importa o guard local
 import { JwtAuthGuard } from './guards/jwt-auth.guard'; // Importa o guard JWT
 import { ApiTags } from '@nestjs/swagger'; // Para organizar no Swagger UI
+import { Public } from './decorators/public.decorator';
+import { UsersService } from '../users/users.service';
+import { RegisterUserDto } from '../users/dto/register-user.dto';
 
 @ApiTags('auth') // Adiciona uma tag para o Swagger UI
 @Controller('auth') // Rota base para autenticação
 export class AuthController {
-  constructor(private authService: AuthService) {}
+  constructor(
+    private authService: AuthService,
+    private usersService: UsersService,
+  ) {}
 
   @UseGuards(LocalAuthGuard) // Protege a rota com a estratégia local
   @Post('login')
@@ -28,5 +37,26 @@ export class AuthController {
   getProfile(@Request() req) {
     // Após o JwtAuthGuard validar o token, o payload estará em req.user
     return req.user;
+  }
+
+  @Public() // ✅ Este decorator torna a rota acessível publicamente
+  @Post('register')
+  @HttpCode(HttpStatus.CREATED)
+  async register(@Body() registerUserDto: RegisterUserDto) {
+    const { email, password } = registerUserDto;
+
+    // 1. Verificação: Garanta que o usuário não exista
+    const existingUser = await this.usersService.findByEmail(email);
+    if (existingUser) {
+      throw new BadRequestException('Este e-mail já está em uso.');
+    }
+
+    // 2. Lógica de registro no AuthService
+    // O AuthService usará o UsersService para criar o usuário
+    const user = await this.authService.register(email, password);
+
+    // 3. Remova a senha do retorno por segurança
+    const { password: userPassword, ...result } = user;
+    return result;
   }
 }

--- a/backend-nest/src/auth/auth.service.ts
+++ b/backend-nest/src/auth/auth.service.ts
@@ -26,4 +26,10 @@ export class AuthService {
       access_token: this.jwtService.sign(payload), // Gera o JWT
     };
   }
+  async register(email: string, password: string) {
+    // Usar o UsersService para criar o novo usuário
+    // A rota pública deve criar um usuário com a role 'user' por padrão
+    const newUser = await this.usersService.create(email, password, ['user']);
+    return newUser;
+  }
 }

--- a/backend-nest/src/users/dto/register-user.dto.ts
+++ b/backend-nest/src/users/dto/register-user.dto.ts
@@ -1,0 +1,13 @@
+// src/auth/dto/register-user.dto.ts
+import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
+
+export class RegisterUserDto {
+  @IsEmail({}, { message: 'Por favor, forneça um e-mail válido.' })
+  @IsNotEmpty()
+  email: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(6, { message: 'A senha deve ter no mínimo 6 caracteres.' })
+  password: string;
+}

--- a/frontend-angular/src/app/auth/auth.service.ts
+++ b/frontend-angular/src/app/auth/auth.service.ts
@@ -28,6 +28,11 @@ export class AuthService {
     this.loadUserFromToken();
   }
 
+  register(userData: any) {
+    // ✅ Use a nova rota pública de registro
+    return this.http.post(`${this.apiUrl}/auth/register`, userData);
+  }
+
   // Verifica se existe um token e se ele é válido (não expirado)
   private hasValidToken(): boolean {
     const token = this.getToken();


### PR DESCRIPTION
This commit introduces a new, public registration endpoint at /auth/register to allow unauthenticated users to create an account.

- **Reasoning:** The existing /users/register route was protected and required an admin JWT, causing a 404 error for public registration attempts.
- **Changes:**
  - Added a new  route in .
  - Marked the new route with the  decorator to bypass JWT authentication.
  - Ensured the endpoint uses  to create a user with the default  role.
  - Updated the frontend's  to point to the new  endpoint.
  - Fixed missing imports in  for  and .

The  endpoint remains in place for admin-level user creation.